### PR TITLE
Use the new mapboxgl.js library

### DIFF
--- a/djangocms_maps/static/djangocms_maps/js/mapbox.js
+++ b/djangocms_maps/static/djangocms_maps/js/mapbox.js
@@ -9,6 +9,11 @@
 
 var djangocms = window.djangocms || {};
 
+var STYLES = {
+    default: 'mapbox://styles/mapbox/streets-v11',
+    satellite: 'mapbox://styles/mapbox/satellite-streets-v11'
+}
+
 /**
  * Mapbox OSM map instances from plugins.
  *
@@ -53,6 +58,7 @@ djangocms.Maps = {
         var data = container.data();
 
         var options = {
+            container: container[0],
             apiKey: data.api_key,
             zoom: data.zoom,
             scrollWheelZoom: data.scrollwheel,
@@ -63,23 +69,29 @@ djangocms.Maps = {
             zoomControl: data.zoom_control,
             layersControl: data.layers_control,
             scaleBar: data.scale_bar,
+            style: STYLES.default,
             styles: data.style,
             center: { lat: 46.94708, lng: 7.445975 } // default to switzerland;
         };
 
-        L.mapbox.accessToken = options.apiKey;
+        mapboxgl.accessToken = options.apiKey;
 
-        var map = L.mapbox.map(container[0], "mapbox.streets", options);
+        var map = new mapboxgl.Map(options);
 
         if (options.layersControl) {
-            L.control.layers({
-                "Streets": L.mapbox.tileLayer("mapbox.streets").addTo(map),
-                "Satellite": L.mapbox.tileLayer("mapbox.satellite"),
-                "Hybrid": L.mapbox.tileLayer("mapbox.streets-satellite")
-            }).addTo(map);
+            var layer = new LayersControl();
+            map.addControl(layer, 'top-left');
+        }
+        if (options.zoomControl || options.panControl) {
+            var nav = new mapboxgl.NavigationControl();
+            map.addControl(nav, 'top-right');
         }
         if (options.scaleBar) {
-            L.control.scale().addTo(map);
+            var scale = new mapboxgl.ScaleControl({
+                maxWidth: 80,
+                unit: 'metric'
+            });
+            map.addControl(scale);
         }
 
         // latitute or longitute have precedence over the address when provided
@@ -91,17 +103,24 @@ djangocms.Maps = {
                 lat: parseFloat(data.lat.replace(",", ".")),
                 lng: parseFloat(data.lng.replace(",", "."))
             };
-            map.setView(latlng, data.zoom);
+            map.jumpTo({center: latlng, zoom: data.zoom});
             this.addMarker(map, latlng, data);
         } else {
             // load latlng from given address
-            L.mapbox.geocoder("mapbox.places").query(data.address, function(err, geodata) {
-                if (geodata.lbounds) {
-                    map.fitBounds(geodata.lbounds);
-                } else if (geodata.latlng) {
-                    var latlng = [geodata.latlng[0], geodata.latlng[1]];
-                    map.setView(latlng, 13);
-                    that.addMarker(map, latlng, data);
+            var geocoder = new MapboxGeocoder({
+                accessToken: mapboxgl.accessToken,
+                mapboxgl: mapboxgl,
+                limit: 1
+            });
+            var geocoderContainer = document.createElement("div");
+            geocoderContainer.setAttribute('style', 'display: none;');
+            container.append(geocoderContainer);
+            geocoder.addTo(geocoderContainer);
+            geocoder.query(data.address).on("results", function(geodata) {
+                if (geodata.features[0].center) {
+                    var center = geodata.features[0].center;
+                    map.jumpTo({center: center, zoom: 13});
+                    that.addMarker(map, center, data);
                 }
             });
         }
@@ -117,7 +136,9 @@ djangocms.Maps = {
      */
     addMarker: function addMarker(map, latlng, data) {
         var windowContent = "";
-        var marker = L.marker(latlng).addTo(map);
+        var marker = new mapboxgl.Marker()
+            .setLngLat(latlng)
+            .addTo(map);
 
         if (data.show_infowindow) {
             // prepare info window
@@ -131,13 +152,58 @@ djangocms.Maps = {
                 windowContent += "<br /><em>" + data.info_content + "</em>";
             }
 
-            marker.bindPopup(windowContent).openPopup();
+            var popup = new mapboxgl.Popup({ offset: 25 }).setHTML(windowContent);
+            marker.setPopup(popup).togglePopup()
         }
 
         // reposition map
         map.panTo(latlng);
     }
+};
 
+function LayersControl() { }
+
+LayersControl.prototype.onAdd = function(map) {
+    this._map = map;
+    this._container = document.createElement('div');
+    this._container.className = 'mapboxgl-ctrl-layers mapboxgl-ctrl-group mapboxgl-ctrl';
+   
+    var that = this;
+    var inputs = [];
+    Object.keys(STYLES).forEach(function(key, index) {
+        var input = document.createElement('input');
+        input.setAttribute('id', 'layers_control_' + key);
+        input.setAttribute('type', 'radio');
+        input.setAttribute('name', 'layers-toggle');
+        input.setAttribute('value', key);
+        if (index == 0) {
+            input.setAttribute('checked', 'checked');
+        }
+        that._container.append(input);
+
+        var label = document.createElement('label');
+        label.setAttribute('for', input.id);
+        label.innerText = key;
+        that._container.append(label);
+
+        inputs.push(input);
+    });
+
+    function switchLayer(layer) {
+        var styleId = layer.target.value;
+        map.setStyle(STYLES[styleId]);
+    }
+        
+    $(inputs).each(function (index, input) {
+        $(inputs).click(switchLayer);
+    })
+    
+    return this._container;
+};
+
+LayersControl.prototype.onRemove = function () {
+    this._container.parentNode.removeChild(this._container);
+    this._map = undefined;
 };
 
 // initializes all occurring Maps plugins at once.

--- a/djangocms_maps/templates/djangocms_maps/maps.html
+++ b/djangocms_maps/templates/djangocms_maps/maps.html
@@ -24,5 +24,5 @@
         data-lang_code="{{ LANGUAGE_CODE }}"
         style="{% if object.width %}width: {{ object.width }}; {% endif %}{% if object.height %}height: {{ object.height }};{% endif %}">
     </div>
+    {% include "djangocms_maps/provider/"|add:object.map_provider|add:".html" %}
 </div>
-{% include "djangocms_maps/provider/"|add:object.map_provider|add:".html" %}

--- a/djangocms_maps/templates/djangocms_maps/provider/mapbox.html
+++ b/djangocms_maps/templates/djangocms_maps/provider/mapbox.html
@@ -1,5 +1,45 @@
-{% load staticfiles sekizai_tags %}
+{% load staticfiles sekizai_tags i18n %}
 
-{% addtoblock "css" %}<link href="https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css" rel="stylesheet" />{% endaddtoblock %}
-{% addtoblock "js" %}<script src="https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js"></script>{% endaddtoblock %}
-{% addtoblock "js" %}<script src="{% static 'djangocms_maps/js/mapbox.js' %}"></script>{% endaddtoblock %}
+{% if object.layers_control %}
+{% comment %}
+  <div class="djangocms-maps-style-menu">
+    <!-- See a list of Mapbox-hosted public styles at -->
+    <!-- https://docs.mapbox.com/api/maps/styles/#mapbox-styles -->
+    <input id="style_toggle_default" type="radio" name="style-toggle" value="default" checked="checked">
+    <label for="style_toggle_default">{% trans "Default" %}</label>
+    <input id="style_toggle_satellite" type="radio" name="style-toggle" value="satellite">
+    <label for="style_toggle_satellite">{% trans "Satellite" %}</label>
+  </div>
+{% endcomment %}
+{% endif %}
+
+{% addtoblock "css" %}
+  <link href="https://api.mapbox.com/mapbox-gl-js/v2.3.0/mapbox-gl.css" rel="stylesheet">
+  {% block djangocms-maps-style %}
+    <style>
+      .djangocms-maps {
+        position: relative;
+      }
+
+      .mapboxgl-ctrl-layers {
+        padding: 7px 10px 10px 10px;
+      }
+      
+      .mapboxgl-ctrl-layers label {
+        margin: 0 1em 0 .25em;
+      }
+
+      .mapboxgl-ctrl-layers label:last-child {
+        margin-right: 0;
+      }
+    </style>
+  {% endblock djangocms-maps-style %}
+{% endaddtoblock %}
+
+{% addtoblock "js" %}
+  <script src="https://api.mapbox.com/mapbox-gl-js/v2.3.0/mapbox-gl.js"></script>
+  {% if not object.lat and not object.lng %}
+    <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.7.0/mapbox-gl-geocoder.min.js"></script>
+  {% endif %}
+  <script src="{% static 'djangocms_maps/js/mapbox.js' %}"></script>
+{% endaddtoblock %}


### PR DESCRIPTION
Replace old mapbox.js library by MapboxGL.js.
![Capture d’écran 2021-06-24 à 16 32 17](https://user-images.githubusercontent.com/1597706/123281367-ed719d00-d509-11eb-8a3c-e751768d718a.png)
